### PR TITLE
Remove trailing slashes (instead of adding them)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -2,6 +2,7 @@
   "hosting": {
     "public": "build",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "trailingSlash": false,
     "rewrites": [
       {
         "source": "**",


### PR DESCRIPTION
Firebase hosting doesn't remove trailing slashes.  That breaks relative links. For example, a relative link on overview.mdx will break when a user visits https://docs.valora.xyz/listing/overview/ (vs https://docs.valora.xyz/listing/overview)